### PR TITLE
Filter presets added

### DIFF
--- a/src/Frontend/Pages/ReportDetails.razor
+++ b/src/Frontend/Pages/ReportDetails.razor
@@ -28,198 +28,26 @@
 		}
 		else
 		{
-			var cpu = report.CPU;
-			var os = report.OperatingSystem;
-			var system = report.System;
-			var docker = report.DockerInfo;
-
 			<div class="accordion">
 				<div class="card">
 					<div class="card-header">
 						<h2 class="mb-0">
-							<button class="btn btn-block text-primary text-left" type="button" @onclick="ToggleSystemInfoPanel">
+							<button class="btn btn-block text-primary text-left" @onclick="ToggleSystemInfoPanel">
 								<i class="fa @(HideSystemInformation ? "fa-angle-right" : "fa-angle-down")"></i>&nbsp;&nbsp;System Information
 							</button>
 						</h2>
 					</div>
 
 					<div class="collapse@(HideSystemInformation ? "" : ".show")">
-						<div class="row">
-							<div class="col-2">
-								<div class="list-group" id="list-tab" role="tablist">
-									@if (cpu != null)
-									{
-										<a class="list-group-item list-group-item-action active" id="cpu-list" data-toggle="list" href="#cpu-info" role="tab" aria-controls="cpu">CPU</a>
-									}
-									@if (os != null)
-									{
-										<a class="list-group-item list-group-item-action" id="os-list" data-toggle="list" href="#os-info" role="tab" aria-controls="os">Operating System</a>
-									}
-									@if (system != null)
-									{
-										<a class="list-group-item list-group-item-action" id="system-list" data-toggle="list" href="#system-info" role="tab" aria-controls="system">System</a>
-									}
-									@if (docker != null)
-									{
-										<a class="list-group-item list-group-item-action" id="docker-list" data-toggle="list" href="#docker-info" role="tab" aria-controls="docker">Docker</a>
-									}
-								</div>
-							</div>
-							<div class="col">
-								<div class="tab-content" id="nav-tabContent">
-									@if (cpu != null)
-									{
-										<div class="tab-pane fade show active" id="cpu-info" role="tabpanel" aria-labelledby="cpu-list">
-											<div class="row">
-												<div class="col">
-													<table class="table table-sm">
-														<tbody>
-															<ValueTableRow Label="Manufacturer" Value="cpu.Manufacturer" />
-															<ValueTableRow Label="Brand" Value="cpu.Brand" />
-															<ValueTableRow Label="Vendor" Value="cpu.Vendor" />
-															<ValueTableRow Label="Family" Value="cpu.Family" />
-															<ValueTableRow Label="Model" Value="cpu.Model" />
-															<ValueTableRow Label="Stepping" Value="cpu.Stepping" />
-															<ValueTableRow Label="Revision" Value="cpu.Revision" />
-															<ValueTableRow Label="# Cores" Value="cpu.Cores" />
-															<ValueTableRow Label="# Physical cores" Value="cpu.PhysicalCores" />
-															<ValueTableRow Label="# Processors" Value="cpu.Processors" />
-														</tbody>
-													</table>
-												</div>
-												<div class="col">
-													<table class="table table-sm">
-														<tbody>
-															<ValueTableRow Label="Speed" Value="cpu.Speed" />
-															<ValueTableRow Label="Minimum speed" Value="cpu.MinimumSpeed" />
-															<ValueTableRow Label="Maximum speed" Value="cpu.MaximumSpeed" />
-															<ValueTableRow Label="Voltage" Value="cpu.Voltage" />
-															<ValueTableRow Label="Governor" Value="cpu.Governor" />
-															<ValueTableRow Label="Socket" Value="cpu.Socket" />
-															@if (cpu.FlagValues != null)
-															{
-																<tr>
-																	<th scope="row">Flags:</th>
-																	<td>@string.Join(", ", cpu.FlagValues.OrderBy(f => f))</td>
-																</tr>
-															}
-															<ValueTableRow Label="Virtualization" Value="cpu.Virtualization" />
-															@if (cpu.Cache != null && cpu.Cache.Count > 0)
-															{
-																<tr>
-																	<th scope="row">Cache:</th>
-																	<td>
-																		<table class="table table-sm table-borderless">
-																			<tbody>
-																				@foreach (var cacheLine in cpu.Cache)
-																				{
-																					<tr>
-																						<th scope="row">@(cacheLine.Key):</th>
-																						<rd>@cacheLine.Value</rd>
-																					</tr>
-																				}
-																				</tbody>
-																			</table>
-																		</td>
-																	</tr>
-																}
-															</tbody>
-														</table>
-													</div>
-												</div>
-											</div>
-										}
-										@if (os != null)
-										{
-											<div class="tab-pane fade" id="os-info" role="tabpanel" aria-labelledby="os-list">
-												<div class="row">
-													<div class="col">
-														<table class="table table-sm">
-															<tbody>
-																<ValueTableRow Label="Platform" Value="@os.Platform" />
-																<ValueTableRow Label="Distribution" Value="@os.Distribution" />
-																<ValueTableRow Label="Release" Value="@os.Release" />
-																<ValueTableRow Label="Code name" Value="@os.CodeName" />
-																<ValueTableRow Label="Kernel" Value="@os.Kernel" />
-																<ValueTableRow Label="Architecture" Value="@os.Architecture" />
-															</tbody>
-														</table>
-													</div>
-													<div class="col">
-														<table class="table table-sm">
-															<tbody>
-																<ValueTableRow Label="Code page" Value="@os.CodePage" />
-																<ValueTableRow Label="Logo file" Value="@os.LogoFile" />
-																<ValueTableRow Label="Build" Value="@os.Build" />
-																<ValueTableRow Label="Serive pack" Value="@os.ServicePack" />
-																<ValueTableRow Label="UEFI" Value="@os.IsUefi" />
-															</tbody>
-														</table>
-													</div>
-												</div>
-											</div>
-										}
-										@if (system != null)
-										{
-											<div class="tab-pane fade" id="system-info" role="tabpanel" aria-labelledby="system-list">
-												<div class="row">
-													<div class="col">
-														<table class="table table-sm">
-															<tbody>
-																<ValueTableRow Label="Manufacturer" Value="@system.Manufacturer" />
-																<ValueTableRow Label="SKU" Value="@system.SKU" />
-																<ValueTableRow Label="Virtual" Value="@system.IsVirtual" />
-															</tbody>
-														</table>
-													</div>
-													<div class="col">
-														<table class="table table-sm">
-															<tbody>
-																<ValueTableRow Label="Model" Value="@system.Model" />
-																<ValueTableRow Label="Version" Value="@system.Version" />
-															</tbody>
-														</table>
-													</div>
-												</div>
-											</div>
-										}
-										@if (docker != null)
-										{
-											<div class="tab-pane fade" id="docker-info" role="tabpanel" aria-labelledby="docker-list">
-												<div class="row">
-													<div class="col">
-														<table class="table table-sm">
-															<tbody>
-																<ValueTableRow Label="Kernel version" Value="@docker.KernelVersion" />
-																<ValueTableRow Label="Operating system" Value="@docker.OperatingSystem" />
-																<ValueTableRow Label="OS version" Value="@docker.OSVersion" />
-																<ValueTableRow Label="OS type" Value="@docker.OSType" />
-															</tbody>
-														</table>
-													</div>
-													<div class="col">
-														<table class="table table-sm">
-															<tbody>
-																<ValueTableRow Label="Architecture" Value="@docker.Architecture" />
-																<ValueTableRow Label="# CPUs" Value="@docker.CPUCount" />
-																<ValueTableRow Label="Total memory" Value="@docker.TotalMemory" />
-																<ValueTableRow Label="Server version" Value="@docker.ServerVersion" />
-															</tbody>
-														</table>
-													</div>
-												</div>
-											</div>
-										}
-								</div>
-							</div>
-						</div>
+						<SystemInformation Report="report" />
 					</div>
 				</div>
+
 				<div class="card">
 					<div class="card-header">
 						<h2 class="mb-0">
-							<button class="btn btn-block text-primary text-left" type="button" @onclick="ToggleFilterPanel">
-								<i class="fa @(HideFilters ? "fa-angle-right" : "fa-angle-down")"></i>&nbsp;&nbsp;Filters
+							<button class="btn btn-block text-primary text-left" @onclick="ToggleFilterPanel">
+								<i class="fa @(HideFilters ? "fa-angle-right" : "fa-angle-down")"></i>&nbsp;&nbsp;Filter
 							</button>
 						</h2>
 					</div>
@@ -238,6 +66,7 @@
 									</select>
 								</div>
 							</div>
+
 							<div class="col-auto form-group">
 								<label>Parallelism:</label>
 								<div class="form-check">
@@ -253,6 +82,7 @@
 									</label>
 								</div>
 							</div>
+
 							<div class="col-auto form-group">
 								<label>Algorithm:</label>
 								<div class="form-check">
@@ -274,6 +104,7 @@
 									</label>
 								</div>
 							</div>
+
 							<div class="col-auto form-group">
 								<label>Faithful:</label>
 								<div class="form-check">
@@ -289,6 +120,7 @@
 									</label>
 								</div>
 							</div>
+
 							<div class="col-auto form-group">
 								<label>Bits per prime:</label>
 								<div class="form-check">
@@ -313,7 +145,46 @@
 						</div>
 						<div class="row mx-2 mb-3">
 							<div class="col">
-								<button class="btn btn-primary" disabled="@AreFiltersClear" @onclick="ClearFilters">Clear</button>
+								<button class="btn btn-primary" disabled="@AreFiltersClear" @onclick="ClearFilters">Clear filter</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="card">
+				<div class="card-header">
+					<h2 class="mb-0">
+						<button class="btn btn-block text-primary text-left" @onclick="ToggleFilterPresetPanel">
+							<i class="fa @(HideFilterPresets ? "fa-angle-right" : "fa-angle-down")"></i>&nbsp;&nbsp;Filter presets
+						</button>
+					</h2>
+				</div>
+
+				<div class="collapse@(HideFilterPresets ? "" : ".show")">
+					<div class="row">
+						<div class="col">
+							<div class="list-group list-group-flush">
+								@for (int i = 0; i < (filterPresets?.Count ?? 0); i++)
+								{
+									int presetIndex = i;
+									var preset = filterPresets[presetIndex];
+
+									<div class="list-group-item py-0 pl-2 pr-0 d-flex justify-content-between align-items-center">
+										<button class="btn btn-link @(string.Equals(preset.Name, filterPresetName, StringComparison.OrdinalIgnoreCase) ? "text-danger" : "text-primary") pl-0 text-left " @onclick="async () => await ApplyFilterPreset(presetIndex)">
+											@preset.Name
+										</button>
+										<button class="btn btn-danger" style="box-shadow: none" @onclick="() => RemoveFilterPreset(presetIndex)">
+											<i class="fas fa-minus"></i>
+										</button>
+									</div>
+								}
+								<form @onsubmit="AddFilterPreset" class="list-group-item p-0 d-flex justify-content-between align-items-center">
+									<input type="text" class="form-control" placeholder="New preset name" @bind="filterPresetName" @bind:event="oninput" >
+									<button type="submit" class="btn btn-success" disabled=@(string.IsNullOrWhiteSpace(filterPresetName))>
+										<i class="fas fa-plus"></i>
+									</button>
+								</form>
 							</div>
 						</div>
 					</div>

--- a/src/Frontend/Shared/SystemInformation.razor
+++ b/src/Frontend/Shared/SystemInformation.razor
@@ -1,0 +1,184 @@
+﻿@using PrimeView.Entities;
+
+@{
+	var cpu = Report.CPU;
+	var os = Report.OperatingSystem;
+	var system = Report.System;
+	var docker = Report.DockerInfo;
+}
+
+<div class="row">
+	<div class="col-2">
+		<div class="list-group" id="list-tab" role="tablist">
+			@if (cpu != null)
+			{
+				<a class="list-group-item list-group-item-action active" id="cpu-list" data-toggle="list" href="#cpu-info" role="tab" aria-controls="cpu">CPU</a>			
+			}
+			@if (os != null)
+			{
+				<a class="list-group-item list-group-item-action" id="os-list" data-toggle="list" href="#os-info" role="tab" aria-controls="os">Operating System</a>			
+			}
+			@if (system != null)
+			{
+				<a class="list-group-item list-group-item-action" id="system-list" data-toggle="list" href="#system-info" role="tab" aria-controls="system">System</a>			
+			}
+			@if (docker != null)
+			{
+				<a class="list-group-item list-group-item-action" id="docker-list" data-toggle="list" href="#docker-info" role="tab" aria-controls="docker">Docker</a>			
+			}
+		</div>
+	</div>
+	<div class="col">
+		<div class="tab-content" id="nav-tabContent">
+			@if (cpu != null)
+			{
+				<div class="tab-pane fade show active" id="cpu-info" role="tabpanel" aria-labelledby="cpu-list">
+					<div class="row">
+						<div class="col">
+							<table class="table table-sm">
+								<tbody>
+									<ValueTableRow Label="Manufacturer" Value="cpu.Manufacturer" />
+									<ValueTableRow Label="Brand" Value="cpu.Brand" />
+									<ValueTableRow Label="Vendor" Value="cpu.Vendor" />
+									<ValueTableRow Label="Family" Value="cpu.Family" />
+									<ValueTableRow Label="Model" Value="cpu.Model" />
+									<ValueTableRow Label="Stepping" Value="cpu.Stepping" />
+									<ValueTableRow Label="Revision" Value="cpu.Revision" />
+									<ValueTableRow Label="# Cores" Value="cpu.Cores" />
+									<ValueTableRow Label="# Physical cores" Value="cpu.PhysicalCores" />
+									<ValueTableRow Label="# Processors" Value="cpu.Processors" />
+								</tbody>
+							</table>
+						</div>
+						<div class="col">
+							<table class="table table-sm">
+								<tbody>
+									<ValueTableRow Label="Speed" Value="cpu.Speed" />
+									<ValueTableRow Label="Minimum speed" Value="cpu.MinimumSpeed" />
+									<ValueTableRow Label="Maximum speed" Value="cpu.MaximumSpeed" />
+									<ValueTableRow Label="Voltage" Value="cpu.Voltage" />
+									<ValueTableRow Label="Governor" Value="cpu.Governor" />
+									<ValueTableRow Label="Socket" Value="cpu.Socket" />
+									@if (cpu.FlagValues != null)
+									{
+										<tr>
+											<th scope="row">Flags:</th>
+											<td>@string.Join(", ", cpu.FlagValues.OrderBy(f => f))</td>
+										</tr>
+									}
+									<ValueTableRow Label="Virtualization" Value="cpu.Virtualization" />
+									@if (cpu.Cache != null && cpu.Cache.Count > 0)
+									{
+										<tr>
+											<th scope="row">Cache:</th>
+											<td>
+												<table class="table table-sm table-borderless">
+													<tbody>
+														@foreach (var cacheLine in cpu.Cache)
+														{
+															<tr>
+																<th scope="row">@(cacheLine.Key):</th>
+																<rd>@cacheLine.Value</rd>
+															</tr>
+														}
+													</tbody>
+												</table>
+											</td>
+										</tr>
+									}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			}
+			@if (os != null)
+			{
+				<div class="tab-pane fade" id="os-info" role="tabpanel" aria-labelledby="os-list">
+					<div class="row">
+						<div class="col">
+							<table class="table table-sm">
+								<tbody>
+									<ValueTableRow Label="Platform" Value="@os.Platform" />
+									<ValueTableRow Label="Distribution" Value="@os.Distribution" />
+									<ValueTableRow Label="Release" Value="@os.Release" />
+									<ValueTableRow Label="Code name" Value="@os.CodeName" />
+									<ValueTableRow Label="Kernel" Value="@os.Kernel" />
+									<ValueTableRow Label="Architecture" Value="@os.Architecture" />
+								</tbody>
+							</table>
+						</div>
+						<div class="col">
+							<table class="table table-sm">
+								<tbody>
+									<ValueTableRow Label="Code page" Value="@os.CodePage" />
+									<ValueTableRow Label="Logo file" Value="@os.LogoFile" />
+									<ValueTableRow Label="Build" Value="@os.Build" />
+									<ValueTableRow Label="Serive pack" Value="@os.ServicePack" />
+									<ValueTableRow Label="UEFI" Value="@os.IsUefi" />
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			}
+			@if (system != null)
+			{
+				<div class="tab-pane fade" id="system-info" role="tabpanel" aria-labelledby="system-list">
+					<div class="row">
+						<div class="col">
+							<table class="table table-sm">
+								<tbody>
+									<ValueTableRow Label="Manufacturer" Value="@system.Manufacturer" />
+									<ValueTableRow Label="SKU" Value="@system.SKU" />
+									<ValueTableRow Label="Virtual" Value="@system.IsVirtual" />
+								</tbody>
+							</table>
+						</div>
+						<div class="col">
+							<table class="table table-sm">
+								<tbody>
+									<ValueTableRow Label="Model" Value="@system.Model" />
+									<ValueTableRow Label="Version" Value="@system.Version" />
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			}
+			@if (docker != null)
+			{
+				<div class="tab-pane fade" id="docker-info" role="tabpanel" aria-labelledby="docker-list">
+					<div class="row">
+						<div class="col">
+							<table class="table table-sm">
+								<tbody>
+									<ValueTableRow Label="Kernel version" Value="@docker.KernelVersion" />
+									<ValueTableRow Label="Operating system" Value="@docker.OperatingSystem" />
+									<ValueTableRow Label="OS version" Value="@docker.OSVersion" />
+									<ValueTableRow Label="OS type" Value="@docker.OSType" />
+								</tbody>
+							</table>
+						</div>
+						<div class="col">
+							<table class="table table-sm">
+								<tbody>
+									<ValueTableRow Label="Architecture" Value="@docker.Architecture" />
+									<ValueTableRow Label="# CPUs" Value="@docker.CPUCount" />
+									<ValueTableRow Label="Total memory" Value="@docker.TotalMemory" />
+									<ValueTableRow Label="Server version" Value="@docker.ServerVersion" />
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			}
+		</div>
+	</div>
+</div>
+
+@code 
+{
+	[Parameter]
+	public Report Report { get; set; }
+}

--- a/src/Frontend/Tools/ResultFilterPreset.cs
+++ b/src/Frontend/Tools/ResultFilterPreset.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace PrimeView.Frontend.Tools
+{
+	public class ResultFilterPreset
+	{
+		[JsonPropertyName("nm")]
+		public string Name { get; set; } 
+
+		[JsonPropertyName("it")]
+		public string ImplementationText { get; set; }
+		
+		[JsonPropertyName("pt")]
+		public string ParallelismText { get; set; }
+
+		[JsonPropertyName("at")]
+		public string AlgorithmText { get; set; }
+
+		[JsonPropertyName("ft")]
+		public string FaithfulText { get; set; }
+
+		[JsonPropertyName("bt")]
+		public string BitsText { get; set; }
+	}
+}

--- a/src/Frontend/wwwroot/js/app.js
+++ b/src/Frontend/wwwroot/js/app.js
@@ -21,3 +21,9 @@ PrimeViewJS.ClearMultiselectValues = function (element) {
 			element.options[i].selected = false;
 	}
 };
+
+PrimeViewJS.SetMultiselectValues = function (element, values) {
+	for (var i = 0; i < element.length; i++) {
+		element.options[i].selected = values.includes(element.options[i].value);
+	}
+};


### PR DESCRIPTION
It is now possible to create, apply, remove and overwrite filter presets, that being sets of filter settings defined via the filter controls added in the last PR. The presets can be named whatever you want and are saved in local storage thus persisted across reports and browser sessions. 