### PR TITLE
Add GitHub Pages deploy action

### DIFF
--- a/.github/workflows/azure-static-web-apps-agreeable-mud-0b27ba210.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-mud-0b27ba210.yml
@@ -3,11 +3,11 @@ name: Azure Static Web Apps CI/CD
 on:
   push:
     branches:
-      - main
+      - staging
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - main
+      - staging
 
 jobs:
   build_and_deploy_job:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,48 @@
+name: Deploy to GitHub Pages
+
+# Run workflow on every push to the master branch
+on:
+  push:
+    branches: 
+      - master
+
+jobs:
+  deploy-to-github-pages:
+    # use ubuntu-latest image to run steps on
+    runs-on: ubuntu-latest
+    steps:
+    # uses GitHub's checkout action to checkout code form the master branch
+    - uses: actions/checkout@v2
+    
+    # sets up .NET Core SDK 3.1
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+
+    # publishes Blazor project to the release-folder
+    - name: Publish Frontend project
+      run: dotnet publish src/Frontend/Frontend.csproj -c Release -o release --nologo
+    
+    # changes the base-tag in index.html from '/' to 'BlazorGitHubPagesDemo' to match GitHub Pages repository subdirectory
+    - name: Change base-tag in index.html from / to PrimeView
+      run: sed -i 's/<base href="\/" \/>/<base href="\/PrimeView\/" \/>/g' release/wwwroot/index.html
+    
+    # copy index.html to 404.html to serve the same file when a file is not found
+    - name: Copy index.html to 404.html
+      run: cp release/wwwroot/index.html release/wwwroot/404.html
+
+    # remove Azure static web app config
+    - name: Remove Azure static web app config
+      run: rm release/wwwroot/staticwebapp.*
+
+    # add .nojekyll file to tell GitHub pages to not treat this as a Jekyll project. (Allow files and folders starting with an underscore)
+    - name: Add .nojekyll file
+      run: touch release/wwwroot/.nojekyll
+      
+    - name: Commit wwwroot to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@4.1.4
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: pages
+        FOLDER: release/wwwroot

--- a/src/Frontend/wwwroot/data/langmap.json
+++ b/src/Frontend/wwwroot/data/langmap.json
@@ -3,6 +3,10 @@
 		"name": "Ada",
 		"url": "https://en.wikipedia.org/wiki/Ada_(programming_language)"
 	},
+	"apl": {
+		"name": "APL",
+		"url": "https://en.wikipedia.org/wiki/APL_(programming_language)"
+	},
 	"assembly": {
 		"name": "Assembly",
 		"url": "https://en.wikipedia.org/wiki/Assembly_language"


### PR DESCRIPTION
Added a GitHub Actions workflow to publish PrimeView to the `pages` branch, in preparation for it being published as an actual Pages site. It also updates the static web apps workflow to trigger on the staging branch, which is now the default.