### PR TITLE
Add fixed Leaderboard filter, rearrange bit filter options

### DIFF
--- a/src/Frontend/Filters/LeaderboardFilterPreset.cs
+++ b/src/Frontend/Filters/LeaderboardFilterPreset.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PrimeView.Frontend.Filters
+{
+	public class LeaderboardFilterPreset : ResultFilterPreset
+	{
+		public LeaderboardFilterPreset()
+		{
+			Name = "Leaderboard";
+			ImplementationText = "";
+			ParallelismText = "mt";
+			AlgorithmText = "wh~ot";
+			FaithfulText = "uf";
+			BitsText = "uk~ot";
+		}
+
+		public override bool IsFixed => true;
+	}
+}

--- a/src/Frontend/Filters/ResultFilterPreset.cs
+++ b/src/Frontend/Filters/ResultFilterPreset.cs
@@ -21,5 +21,8 @@ namespace PrimeView.Frontend.Filters
 
 		[JsonPropertyName("bt")]
 		public string BitsText { get; set; }
+
+		[JsonIgnore]
+		public virtual bool IsFixed => false;
 	}
 }

--- a/src/Frontend/Pages/Index.razor
+++ b/src/Frontend/Pages/Index.razor
@@ -21,10 +21,10 @@
 			@{ OnTableRefreshStart(); }
 			<Column TableItem="ReportSummary" Title="Date" Field="@(s => s.Date)" Sortable="true" Filterable="true">
 				<Template>
-					<button class="btn btn-link" @onclick="() => LoadReport(context.Id)">@context.Date?.ToLocalTime()</button>
+					<button class="btn btn-link py-0" @onclick="() => LoadReport(context.Id)">@context.Date?.ToLocalTime()</button>
 				</Template>
 			</Column>
-			<Column TableItem="ReportSummary" Title="User" Field="@(s => s.User)" Sortable="true" Filterable="true">
+			<Column TableItem="ReportSummary" Title="User" Field="@(s => s.User)" Sortable="true" Filterable="true" Class="align-middle">
 				<CustomIFilters>
 					<CustomSelect TableItem="ReportSummary">
 						@foreach (var user in summaries.Select(r => r.User).Where(u => u != null).Distinct().OrderBy(u => u))
@@ -34,14 +34,14 @@
 					</CustomSelect>
 				</CustomIFilters>
 			</Column>
-			<Column TableItem="ReportSummary" Title="CPU Vendor" Field="@(s => s.CpuVendor)" Sortable="true" Filterable="true" />
-			<Column TableItem="ReportSummary" Title="CPU Brand" Field="@(s => s.CpuBrand)" Sortable="true" Filterable="true" />
-			<Column TableItem="ReportSummary" Title="# Processors" Field="@(s => s.CpuProcessors)" Sortable="true" Filterable="true" />
-			<Column TableItem="ReportSummary" Title="# Cores" Field="@(s => s.CpuCores)" Sortable="true" Filterable="true" />
-			<Column TableItem="ReportSummary" Title="Platform" Field="@(s => s.OsPlatform)" Sortable="true" Filterable="true" />
-			<Column TableItem="ReportSummary" Title="OS Release" Field="@(s => s.OsRelease)" Sortable="true" Filterable="true" />
-			<Column TableItem="ReportSummary" Title="Architecture" Field="@(s => s.Architecture)" Sortable="true" Filterable="true" />
-			<Column TableItem="ReportSummary" Title="Virtual" Field="@(s => s.IsSystemVirtual)" Sortable="true" Filterable="true">
+			<Column TableItem="ReportSummary" Title="CPU Vendor" Field="@(s => s.CpuVendor)" Sortable="true" Filterable="true" Class="align-middle" />
+			<Column TableItem="ReportSummary" Title="CPU Brand" Field="@(s => s.CpuBrand)" Sortable="true" Filterable="true" Class="align-middle" />
+			<Column TableItem="ReportSummary" Title="# Processors" Field="@(s => s.CpuProcessors)" Sortable="true" Filterable="true" Align="Align.Right" Class="align-middle" />
+			<Column TableItem="ReportSummary" Title="# Cores" Field="@(s => s.CpuCores)" Sortable="true" Filterable="true" Align="Align.Right" Class="align-middle" />
+			<Column TableItem="ReportSummary" Title="Platform" Field="@(s => s.OsPlatform)" Sortable="true" Filterable="true" Class="align-middle" />
+			<Column TableItem="ReportSummary" Title="OS Release" Field="@(s => s.OsRelease)" Sortable="true" Filterable="true" Class="align-middle" />
+			<Column TableItem="ReportSummary" Title="Architecture" Field="@(s => s.Architecture)" Sortable="true" Filterable="true" Class="align-middle" />
+			<Column TableItem="ReportSummary" Title="Virtual" Field="@(s => s.IsSystemVirtual)" Sortable="true" Filterable="true" Class="align-middle">
 				<CustomIFilters>
 					<CustomSelect TableItem="ReportSummary">
 						<CustomSelectOption Key="yes" Value="@("True")" />
@@ -54,7 +54,7 @@
 			</Column>
 			<Column TableItem="ReportSummary" Title="# Results" Field="@(s => s.ResultCount)" Sortable="true" Filterable="true">
 				<Template>
-					<button class="btn btn-link" @onclick="() => LoadReport(context.Id)">@context.ResultCount</button>
+					<button class="btn btn-link py-0" @onclick="() => LoadReport(context.Id)">@context.ResultCount</button>
 				</Template>
 			</Column>
 			<Pager ShowPageNumber="true" ShowTotalCount="true" ShowPageSizes="true" AlwaysShow="true"/>

--- a/src/Frontend/Pages/ReportDetails.razor
+++ b/src/Frontend/Pages/ReportDetails.razor
@@ -128,12 +128,6 @@
 							<div class="col-auto form-group">
 								<label>Bits per prime:</label>
 								<div class="form-check">
-									<input class="form-check-input" type="checkbox" id="fb_uk" @bind="FilterBitsUnknown">
-									<label class="form-check-label" for="fb_uk">
-										<em>Unknown</em>
-									</label>
-								</div>
-								<div class="form-check">
 									<input class="form-check-input" type="checkbox" id="fb_on" @bind="FilterBitsOne">
 									<label class="form-check-label" for="fb_on">
 										1
@@ -143,6 +137,12 @@
 									<input class="form-check-input" type="checkbox" id="fb_ot" @bind="FilterBitsOther">
 									<label class="form-check-label" for="fb_ot">
 										&gt;1
+									</label>
+								</div>
+								<div class="form-check">
+									<input class="form-check-input" type="checkbox" id="fb_uk" @bind="FilterBitsUnknown">
+									<label class="form-check-label" for="fb_uk">
+										<em>Unknown</em>
 									</label>
 								</div>
 							</div>

--- a/src/Frontend/Pages/ReportDetails.razor
+++ b/src/Frontend/Pages/ReportDetails.razor
@@ -175,7 +175,7 @@
 									var preset = filterPresets[presetIndex];
 
 									<div class="list-group-item py-1 pl-2 pr-0 d-flex justify-content-between align-items-center">
-										<button class="btn btn-link @(preset.IsFixed ? "text-dark" : (string.Equals(preset.Name, filterPresetName?.Trim(), StringComparison.OrdinalIgnoreCase)) ? "text-success" : "text-primary") pl-0 text-left " @onclick="async () => await ApplyFilterPreset(presetIndex)">
+										<button class="btn btn-link @(preset.IsFixed ? "text-dark" : (string.Equals(preset.Name, filterPresetName?.Trim(), StringComparison.OrdinalIgnoreCase)) ? "text-success" : "text-primary") px-1 text-left " @onclick="async () => await ApplyFilterPreset(presetIndex)">
 											@preset.Name
 										</button>
 										<button class="btn btn-danger" style="box-shadow: none" disabled="@(preset.IsFixed)" @onclick="() => RemoveFilterPreset(presetIndex)">
@@ -200,7 +200,7 @@
 			var filteredItems = report.Results.ApplyFilters(this);
 			<Table TableItem="Result" Items="filteredItems" PageSize="0" ColumnReorder="false" ShowFooter="true" @ref="sortedTable" @onclick="FlagTableSortingChange">
 				@{ OnTableRefreshStart(); }
-				<Column TableItem="Result" Title="#" Sortable="false" Filterable="false" SetFooterValue="@($"{filteredItems.Count()}")">
+				<Column TableItem="Result" Title="#" Sortable="false" Filterable="false" SetFooterValue="@($"{filteredItems.Count()}")" Align="Align.Right">
 					<Template>
 						@(++rowNumber)
 					</Template>
@@ -219,7 +219,6 @@
 						@if (languageInfo.URL != null)
 						{
 							<a href="@languageInfo.URL" target="_blank" rel="noreferrer noopener">@languageInfo.Name</a>
-
 						}
 						else
 						{
@@ -227,13 +226,13 @@
 						}
 					</Template>
 				</Column>
-				<Column TableItem="Result" Title="Solution" Field="@(r => r.Solution)" Sortable="false" Filterable="false" />
+				<Column TableItem="Result" Title="Solution" Field="@(r => r.Solution)" Sortable="false" Filterable="false" Align="Align.Right" />
 				<Column TableItem="Result" Title="Label" Field="@(r => r.Label)" Sortable="true" Filterable="true" />
-				<Column TableItem="Result" Title="Passes" Field="@(r => r.Passes)" Sortable="true" Filterable="true" />
+				<Column TableItem="Result" Title="Passes" Field="@(r => r.Passes)" Sortable="true" Filterable="true" Align="Align.Right" />
 				<Column TableItem="Result" Title="Duration" Field="@(r => r.Duration)" Sortable="true" Filterable="true" />
-				<Column TableItem="Result" Title="# Threads" Field="@(r => r.Threads)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => !r.IsMultiThreaded)} single-threaded")" />
+				<Column TableItem="Result" Title="# Threads" Field="@(r => r.Threads)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => !r.IsMultiThreaded)} single-threaded")" Align="Align.Right" />
 				<Column TableItem="Result" Title="Passes/s/t" Field="@(r => r.PassesPerSecond)" Sortable="true" Filterable="true" />
-				<Column TableItem="Result" Title="Multithreaded" Field="@(r => r.IsMultiThreaded)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => r.IsMultiThreaded)} multithreaded")">
+				<Column TableItem="Result" Title="Multithreaded" Field="@(r => r.IsMultiThreaded)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => r.IsMultiThreaded)} multithreaded")" Align="Align.Center">
 					<CustomIFilters>
 						<CustomSelect TableItem="Result">
 							<CustomSelectOption Key="yes" Value="@("True")" />
@@ -244,7 +243,7 @@
 						<span class="text-success">@(context.IsMultiThreaded ? "yes" : "no")</span>
 					</Template>
 				</Column>
-				<Column TableItem="Result" Title="Algorithm" Field="@(r => r.Algorithm)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => r.Algorithm == "base")} base")">
+				<Column TableItem="Result" Title="Algorithm" Field="@(r => r.Algorithm)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => r.Algorithm == "base")} base")" Align="Align.Center">
 					<CustomIFilters>
 						<CustomSelect TableItem="Result">
 							@foreach (var algorithm in report.Results.Select(r => r.Algorithm).Where(a => a != null).Distinct().OrderBy(a => a))
@@ -257,7 +256,6 @@
 						@if (context.Algorithm == "base")
 						{
 							<span class="text-success">@context.Algorithm</span>
-
 						}
 						else
 						{
@@ -265,7 +263,7 @@
 						}
 					</Template>
 				</Column>
-				<Column TableItem="Result" Title="Faithful" Field="@(r => r.IsFaithful)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => r.IsFaithful == true)} faithful")">
+				<Column TableItem="Result" Title="Faithful" Field="@(r => r.IsFaithful)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => r.IsFaithful == true)} faithful")" Align="Align.Center">
 					<CustomIFilters>
 						<CustomSelect TableItem="Result">
 							<CustomSelectOption Key="yes" Value="@("True")" />
@@ -276,7 +274,6 @@
 						@if (context.IsFaithful == true)
 						{
 							<span class="text-success">yes</span>
-
 						}
 						else
 						{
@@ -284,7 +281,7 @@
 						}
 					</Template>
 				</Column>
-				<Column TableItem="Result" Title="Bits" Field="@(r => r.Bits)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => r.Bits == 1)} single-bit")">
+				<Column TableItem="Result" Title="Bits" Field="@(r => r.Bits)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => r.Bits == 1)} single-bit")" Align="Align.Right">
 					<CustomIFilters>
 						<CustomSelect TableItem="Result">
 							@foreach (var bitCount in report.Results.Select(r => r.Bits).Where(b => b != null).Cast<int>().Distinct().OrderBy(b => b))
@@ -301,7 +298,6 @@
 						else if (context.Bits == null)
 						{
 							<em>Unknown</em>
-
 						}
 						else
 						{

--- a/src/Frontend/Pages/ReportDetails.razor
+++ b/src/Frontend/Pages/ReportDetails.razor
@@ -174,18 +174,18 @@
 									int presetIndex = i;
 									var preset = filterPresets[presetIndex];
 
-									<div class="list-group-item py-0 pl-2 pr-0 d-flex justify-content-between align-items-center">
-										<button class="btn btn-link @(string.Equals(preset.Name, filterPresetName?.Trim(), StringComparison.OrdinalIgnoreCase) ? "text-success" : "text-primary") pl-0 text-left " @onclick="async () => await ApplyFilterPreset(presetIndex)">
+									<div class="list-group-item py-1 pl-2 pr-0 d-flex justify-content-between align-items-center">
+										<button class="btn btn-link @(preset.IsFixed ? "text-dark" : (string.Equals(preset.Name, filterPresetName?.Trim(), StringComparison.OrdinalIgnoreCase)) ? "text-success" : "text-primary") pl-0 text-left " @onclick="async () => await ApplyFilterPreset(presetIndex)">
 											@preset.Name
 										</button>
-										<button class="btn btn-danger" style="box-shadow: none" @onclick="() => RemoveFilterPreset(presetIndex)">
+										<button class="btn btn-danger" style="box-shadow: none" disabled="@(preset.IsFixed)" @onclick="() => RemoveFilterPreset(presetIndex)">
 											<i class="fas fa-minus"></i>
 										</button>
 									</div>
 								}
 								<form @onsubmit="AddFilterPreset" class="list-group-item p-0 d-flex justify-content-between align-items-center">
 									<input type="text" class="form-control" placeholder="New preset name" @bind="filterPresetName" @bind:event="oninput">
-									<button type="submit" class="btn btn-success" disabled=@(string.IsNullOrWhiteSpace(filterPresetName))>
+									<button type="submit" class="btn btn-success" disabled=@(!IsFilterPresetNameValid(filterPresetName))>
 										<i class="fas fa-plus"></i>
 									</button>
 								</form>


### PR DESCRIPTION
This adds a baked-in Leaderboard filter, setting the filter in line with Dave's selection for the "official" leaderboard. That being implementations that are single-threaded, use the base algorithm, are faithful and use 1 bit per prime flag.

Also, I moved the _Unknown_ checkbox to the bottom in the filter options, because that actually makes more sense to me.