### PR TITLE
 Add link to Primes repo solution directory in results table

### DIFF
--- a/src/Frontend/Pages/Index.razor
+++ b/src/Frontend/Pages/Index.razor
@@ -17,12 +17,12 @@
 
 		<form class="form-inline my-2" @onsubmit="ApplyNewMaxReportCount">
 			<label>Maximum number of reports to load:</label>
-			<input type="number" class="form-control mx-2" @bind="newMaxReportCount" @bind:event="oninput">
-			<button type="submit" class="btn btn-primary" disabled="@(newMaxReportCount <= 0 || newMaxReportCount == MaxReportCount)">Apply</button>
-			<button class="btn btn-outline-primary" disabled="@(newMaxReportCount == MaxReportCount)" @onclick="() => newMaxReportCount = MaxReportCount">Reset</button>
+			<input type="number" class="form-control mx-2" @bind="this.newMaxReportCount" @bind:event="oninput">
+			<button type="submit" class="btn btn-primary" disabled="@(this.newMaxReportCount <= 0 || this.newMaxReportCount == MaxReportCount)">Apply</button>
+			<button class="btn btn-outline-primary" disabled="@(this.newMaxReportCount == MaxReportCount)" @onclick="() => this.newMaxReportCount = MaxReportCount">Reset</button>
 		</form>
 
-		<Table TableItem="ReportSummary" Items="summaries" @ref="sortedTable" PageSize="0" ColumnReorder="false" @onclick="FlagTableSortingChange">
+		<Table TableItem="ReportSummary" Items="this.summaries" @ref="this.sortedTable" PageSize="0" ColumnReorder="false" @onclick="FlagTableSortingChange">
 			@{ OnTableRefreshStart(); }
 			<Column TableItem="ReportSummary" Title="Date" Field="@(s => s.Date)" Sortable="true" Filterable="true">
 				<Template>
@@ -32,7 +32,7 @@
 			<Column TableItem="ReportSummary" Title="User" Field="@(s => s.User)" Sortable="true" Filterable="true" Class="align-middle">
 				<CustomIFilters>
 					<CustomSelect TableItem="ReportSummary">
-						@foreach (var user in summaries.Select(r => r.User).Where(u => u != null).Distinct().OrderBy(u => u))
+						@foreach (var user in this.summaries.Select(r => r.User).Where(u => u != null).Distinct().OrderBy(u => u))
 						{
 							<CustomSelectOption Key="@user" Value="@user" />
 						}

--- a/src/Frontend/Pages/ReportDetails.razor
+++ b/src/Frontend/Pages/ReportDetails.razor
@@ -19,7 +19,7 @@
 
 		<h1>@ReportTitle</h1>
 
-		@if (report == null)
+		@if (this.report == null)
 		{
 			<div class="row">
 				<div class="col-auto text-success">
@@ -43,7 +43,7 @@
 					</div>
 
 					<div class="collapse@(HideSystemInformation ? "" : ".show")">
-						<SystemInformation Report="report" />
+						<SystemInformation Report="this.report" />
 					</div>
 				</div>
 
@@ -63,7 +63,7 @@
 									<label for="implementatios">Languages:</label>
 									<select multiple class="form-control" id="implementations" @ref="implementationsSelect" @onchange="ImplementationSelectionChanged">
 										@{ var filterImplementations = FilterImplementations; }
-										@foreach (var languageInfo in report.Results.Select(r => GetLanguageInfo(r.Implementation)).Distinct(new LanguageInfo.KeyEqualityComparer()).OrderBy(n => n.Name))
+										@foreach (var languageInfo in this.report.Results.Select(r => GetLanguageInfo(r.Implementation)).Distinct(new LanguageInfo.KeyEqualityComparer()).OrderBy(n => n.Name))
 										{
 											<option value="@languageInfo.Key" selected="@(filterImplementations.Contains(languageInfo.Key))">@languageInfo.Name</option>
 										}
@@ -179,10 +179,10 @@
 					<div class="row">
 						<div class="col">
 							<div class="list-group list-group-flush">
-								@for (int i = 0; i < (filterPresets?.Count ?? 0); i++)
+								@for (int i = 0; i < (this.filterPresets?.Count ?? 0); i++)
 								{
 									int presetIndex = i;
-									var preset = filterPresets[presetIndex];
+									var preset = this.filterPresets[presetIndex];
 
 									<div class="list-group-item py-1 pl-2 pr-0 d-flex justify-content-between align-items-center">
 										<button class="btn btn-link @(preset.IsFixed ? "text-dark" : (string.Equals(preset.Name, filterPresetName?.Trim(), StringComparison.OrdinalIgnoreCase)) ? "text-success" : "text-primary") px-1 text-left " @onclick="async () => await ApplyFilterPreset(presetIndex)">
@@ -207,7 +207,7 @@
 
 			<br />
 
-			var filteredItems = report.Results.ApplyFilters(this);
+			var filteredItems = this.report.Results.ApplyFilters(this);
 			<Table TableItem="Result" Items="filteredItems" PageSize="0" ColumnReorder="false" ShowFooter="true" @ref="sortedTable" @onclick="FlagTableSortingChange">
 				@{ OnTableRefreshStart(); }
 				<Column TableItem="Result" Title="#" Sortable="false" Filterable="false" SetFooterValue="@($"{filteredItems.Count()}")" Align="Align.Right">
@@ -218,7 +218,7 @@
 				<Column TableItem="Result" Title="Language" Field="@(r => r.Implementation)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Select(r => r.Implementation).Distinct().Count()} languages")">
 					<CustomIFilters>
 						<CustomSelect TableItem="Result">
-							@foreach (var languageInfo in report.Results.Select(r => GetLanguageInfo(r.Implementation)).Distinct(new LanguageInfo.KeyEqualityComparer()).OrderBy(n => n.Name))
+							@foreach (var languageInfo in this.report.Results.Select(r => GetLanguageInfo(r.Implementation)).Distinct(new LanguageInfo.KeyEqualityComparer()).OrderBy(n => n.Name))
 							{
 								<CustomSelectOption Key="@languageInfo.Name" Value="@languageInfo.Key" />
 							}
@@ -226,6 +226,7 @@
 					</CustomIFilters>
 					<Template>
 						@{var languageInfo = GetLanguageInfo(context.Implementation);}
+						
 						@if (languageInfo.URL != null)
 						{
 							<a href="@languageInfo.URL" target="_blank" rel="noreferrer noopener">@languageInfo.Name</a>
@@ -238,10 +239,15 @@
 				</Column>
 				<Column TableItem="Result" Title="Solution" Field="@(r => r.Solution)" Sortable="false" Filterable="false" Align="Align.Right">
 					<Template>
-						@{var languageInfo = GetLanguageInfo(context.Implementation);}
 						@if (solutionUrlTemplate != null)
 						{
-							<a href="@(solutionUrlTemplate.Replace("{sln}", context.Solution).Replace("{tag}", languageInfo.Tag ?? languageInfo.Name))" target="_blank" rel="noreferrer noopener">&nbsp;@context.Solution&nbsp;</a>
+							var languageInfo = GetLanguageInfo(context.Implementation);
+
+							var solutionUrl = this.solutionUrlTemplate
+								.Replace("{sln}", context.Solution)
+								.Replace("{tag}", languageInfo.Tag ?? languageInfo.Name);
+
+							<a href="@solutionUrl" target="_blank" rel="noreferrer noopener">&nbsp;@context.Solution&nbsp;</a>
 						}
 						else
 						{
@@ -268,7 +274,7 @@
 				<Column TableItem="Result" Title="Algorithm" Field="@(r => r.Algorithm)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => r.Algorithm == "base")} base")" Align="Align.Center">
 					<CustomIFilters>
 						<CustomSelect TableItem="Result">
-							@foreach (var algorithm in report.Results.Select(r => r.Algorithm).Where(a => a != null).Distinct().OrderBy(a => a))
+							@foreach (var algorithm in this.report.Results.Select(r => r.Algorithm).Where(a => a != null).Distinct().OrderBy(a => a))
 							{
 								<CustomSelectOption Key="@algorithm" Value="@algorithm" />
 							}
@@ -306,7 +312,7 @@
 				<Column TableItem="Result" Title="Bits" Field="@(r => r.Bits)" Sortable="true" Filterable="true" SetFooterValue="@($"{filteredItems.Count(r => r.Bits == 1)} single-bit")" Align="Align.Right">
 					<CustomIFilters>
 						<CustomSelect TableItem="Result">
-							@foreach (var bitCount in report.Results.Select(r => r.Bits).Where(b => b != null).Cast<int>().Distinct().OrderBy(b => b))
+							@foreach (var bitCount in this.report.Results.Select(r => r.Bits).Where(b => b != null).Cast<int>().Distinct().OrderBy(b => b))
 							{
 								<CustomSelectOption Key="@bitCount.ToString()" Value="@bitCount" />
 							}

--- a/src/Frontend/Pages/ReportDetails.razor
+++ b/src/Frontend/Pages/ReportDetails.razor
@@ -236,7 +236,19 @@
 						}
 					</Template>
 				</Column>
-				<Column TableItem="Result" Title="Solution" Field="@(r => r.Solution)" Sortable="false" Filterable="false" Align="Align.Right" />
+				<Column TableItem="Result" Title="Solution" Field="@(r => r.Solution)" Sortable="false" Filterable="false" Align="Align.Right">
+					<Template>
+						@{var languageInfo = GetLanguageInfo(context.Implementation);}
+						@if (solutionUrlTemplate != null)
+						{
+							<a href="@(solutionUrlTemplate.Replace("{sln}", context.Solution).Replace("{tag}", languageInfo.Tag ?? languageInfo.Name))" target="_blank" rel="noreferrer noopener">&nbsp;@context.Solution&nbsp;</a>
+						}
+						else
+						{
+							<span>&nbsp;@context.Solution&nbsp;</span>
+						}
+					</Template>
+				</Column>
 				<Column TableItem="Result" Title="Label" Field="@(r => r.Label)" Sortable="true" Filterable="true" />
 				<Column TableItem="Result" Title="Passes" Field="@(r => r.Passes)" Sortable="true" Filterable="true" Align="Align.Right" />
 				<Column TableItem="Result" Title="Duration" Field="@(r => r.Duration)" Sortable="true" Filterable="true" />

--- a/src/Frontend/Pages/ReportDetails.razor.cs
+++ b/src/Frontend/Pages/ReportDetails.razor.cs
@@ -220,7 +220,7 @@ namespace PrimeView.Frontend.Pages
 		{
 			try
 			{
-				languageMap = await Http.GetFromJsonAsync<Dictionary<string, LanguageInfo>>("data/langmap.json");
+				this.languageMap = await Http.GetFromJsonAsync<Dictionary<string, LanguageInfo>>("data/langmap.json");
 				foreach (var entry in languageMap)
 				{
 					entry.Value.Key = entry.Key;
@@ -231,13 +231,25 @@ namespace PrimeView.Frontend.Pages
 
 		protected override void OnTableRefreshStart()
 		{
-			rowNumber = sortedTable.PageNumber * sortedTable.PageSize;
+			rowNumber = this.sortedTable.PageNumber * this.sortedTable.PageSize;
 
 			base.OnTableRefreshStart();
 		}
 
 		private LanguageInfo GetLanguageInfo(string language)
-			=> languageMap != null && languageMap.ContainsKey(language) ? languageMap[language] : new() { Key = language, Name = language[0].ToString().ToUpper() + language[1..] };
+		{
+			if (this.languageMap == null)
+				this.languageMap = new();
+
+			if (languageMap.ContainsKey(language))
+				return this.languageMap[language];
+
+			LanguageInfo info = new() { Key = language, Name = language[0].ToString().ToUpper() + language[1..] };
+
+			this.languageMap[language] = info;
+
+			return info;
+		}
 
 		private async Task ImplementationSelectionChanged()
 		{
@@ -291,7 +303,7 @@ namespace PrimeView.Frontend.Pages
 
 		private void RemoveFilterPreset(int index)
 		{
-			filterPresets?.RemoveAt(index);
+			this.filterPresets?.RemoveAt(index);
 
 			SaveFilterPresets();
 		}

--- a/src/Frontend/Pages/ReportDetails.razor.cs
+++ b/src/Frontend/Pages/ReportDetails.razor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Configuration;
 using Microsoft.JSInterop;
 using PrimeView.Entities;
 using PrimeView.Frontend.Filters;
@@ -21,6 +22,9 @@ namespace PrimeView.Frontend.Pages
 
 		[Inject]
 		public HttpClient Http { get; set; }
+
+		[Inject]
+		public IConfiguration Configuration { get; set; }
 
 		[Inject]
 		public IReportReader ReportReader { get; set; }
@@ -141,6 +145,7 @@ namespace PrimeView.Frontend.Pages
 			}
 		}
 
+		private string solutionUrlTemplate;
 		private Report report = null;
 		private int rowNumber = 0;
 		private Dictionary<string, LanguageInfo> languageMap = null;
@@ -160,6 +165,7 @@ namespace PrimeView.Frontend.Pages
 
 		protected override async Task OnInitializedAsync()
 		{
+			this.solutionUrlTemplate = Configuration.GetValue<string>(Constants.SolutionUrlTemplate, null);
 			this.report = await ReportReader.GetReport(ReportId);
 			await LoadLanguageMap();
 

--- a/src/Frontend/Sorting/SortedTablePage.razor.cs
+++ b/src/Frontend/Sorting/SortedTablePage.razor.cs
@@ -37,12 +37,12 @@ namespace PrimeView.Frontend.Sorting
 
 		protected override async Task OnAfterRenderAsync(bool firstRender)
 		{
-			(string sortColumn, bool sortDescending) = sortedTable.GetSortParameterValues();
+			(string sortColumn, bool sortDescending) = this.sortedTable.GetSortParameterValues();
 
-			if (!processTableSortingChange && (!SortColumn.EqualsIgnoreCaseOrNull(sortColumn) || SortDescending != sortDescending))
+			if (!this.processTableSortingChange && (!SortColumn.EqualsIgnoreCaseOrNull(sortColumn) || SortDescending != sortDescending))
 			{
-				if (sortedTable.SetSortParameterValues(SortColumn, SortDescending))
-					await sortedTable.UpdateAsync();
+				if (this.sortedTable.SetSortParameterValues(SortColumn, SortDescending))
+					await this.sortedTable.UpdateAsync();
 			}
 
 			UpdateQueryString();
@@ -52,17 +52,17 @@ namespace PrimeView.Frontend.Sorting
 
 		protected void FlagTableSortingChange()
 		{
-			processTableSortingChange = true;
+			this.processTableSortingChange = true;
 		}
 
 		protected virtual void OnTableRefreshStart()
 		{
-			if (!processTableSortingChange)
+			if (!this.processTableSortingChange)
 				return;
 
-			(string sortColumn, bool sortDescending) = sortedTable.GetSortParameterValues();
+			(string sortColumn, bool sortDescending) = this.sortedTable.GetSortParameterValues();
 
-			processTableSortingChange = false;
+			this.processTableSortingChange = false;
 
 			bool queryStringUpdateRequired = false;
 

--- a/src/Frontend/Tools/Constants.cs
+++ b/src/Frontend/Tools/Constants.cs
@@ -4,6 +4,7 @@
 	{
 		public const string MaxReportCount = nameof(MaxReportCount);
 		public const string ActiveReader = nameof(ActiveReader);
+		public const string SolutionUrlTemplate = nameof(SolutionUrlTemplate);
 		public const string Readers = nameof(Readers);
 		public const string JsonFileReader = nameof(JsonFileReader);
 	}

--- a/src/Frontend/Tools/LanguageInfo.cs
+++ b/src/Frontend/Tools/LanguageInfo.cs
@@ -8,6 +8,7 @@ namespace PrimeView.Frontend.Tools
 		public string Key { get; set; }
 		public string Name { get; set; }
 		public string URL { get; set; }
+		public string Tag { get; set; }
 
 		public class KeyEqualityComparer : IEqualityComparer<LanguageInfo>
 		{

--- a/src/Frontend/wwwroot/appsettings.json
+++ b/src/Frontend/wwwroot/appsettings.json
@@ -1,6 +1,7 @@
 {
 	"MaxReportCount": "30",
 	"ActiveReader": "JsonFileReader",
+	"SolutionUrlTemplate": "https://github.com/PlummersSoftwareLLC/Primes/tree/drag-race/Prime{tag}/solution_{sln}",
 	"Readers": {
 		"JsonFileReader": {
 			"BaseURI": "https://primes.fra1.digitaloceanspaces.com/",

--- a/src/Frontend/wwwroot/data/langmap.json
+++ b/src/Frontend/wwwroot/data/langmap.json
@@ -108,6 +108,14 @@
 		"name": "Go",
 		"url": "https://golang.org/"
 	},
+	"groovy": {
+		"name": "Groovy",
+		"url": "https://groovy-lang.org/"
+	},
+	"hack": {
+		"name": "Hack",
+		"url": "https://hacklang.org/"
+	},
 	"haskell": {
 		"name": "Haskell",
 		"url": "https://www.haskell.org/"

--- a/src/Frontend/wwwroot/data/langmap.json
+++ b/src/Frontend/wwwroot/data/langmap.json
@@ -3,6 +3,11 @@
 		"name": "Ada",
 		"url": "https://en.wikipedia.org/wiki/Ada_(programming_language)"
 	},
+	"amd64": {
+		"name": "AMD64 machine code",
+		"url": "https://en.wikipedia.org/wiki/X86-64",
+		"tag": "Amd64"
+	},
 	"apl": {
 		"name": "APL",
 		"url": "https://en.wikipedia.org/wiki/APL_(programming_language)"
@@ -33,7 +38,8 @@
 	},
 	"brainfuck": {
 		"name": "Brainfuck",
-		"url": "https://en.wikipedia.org/wiki/Brainfuck"
+		"url": "https://en.wikipedia.org/wiki/Brainfuck",
+		"tag": "BrainFuck"
 	},
 	"c": {
 		"name": "C",
@@ -45,7 +51,8 @@
 	},
 	"cpp": {
 		"name": "C++",
-		"url": "https://isocpp.org/"
+		"url": "https://isocpp.org/",
+		"tag": "CPP"
 	},
 	"crystal": {
 		"name": "Crystal",
@@ -53,7 +60,8 @@
 	},
 	"csharp": {
 		"name": "C#",
-		"url": "https://docs.microsoft.com/en-us/dotnet/csharp/"
+		"url": "https://docs.microsoft.com/en-us/dotnet/csharp/",
+		"tag": "CSharp"
 	},
 	"cython": {
 		"name": "Cython",
@@ -89,7 +97,8 @@
 	},
 	"fsharp": {
 		"name": "F#",
-		"url": "https://fsharp.org/"
+		"url": "https://fsharp.org/",
+		"tag": "FSharp"
 	},
 	"gdscript": {
 		"name": "GDScript",
@@ -144,7 +153,8 @@
 		"url": "https://en.wikipedia.org/wiki/MIX"
 	},
 	"mixed": {
-		"name": "(mixed)"
+		"name": "(mixed)",
+		"tag": "Mixed"
 	},
 	"nim": {
 		"name": "Nim",
@@ -152,7 +162,8 @@
 	},
 	"nodejs": {
 		"name": "Node.js",
-		"url": "https://nodejs.org/"
+		"url": "https://nodejs.org/",
+		"tag": "NodeJS"
 	},
 	"ocaml": {
 		"name": "OCaml",
@@ -212,7 +223,8 @@
 	},
 	"rexx": {
 		"name": "Rexx",
-		"url": "http://www.rexxinfo.org/"
+		"url": "http://www.rexxinfo.org/",
+		"tag": "REXX"
 	},
 	"ruby": {
 		"name": "Ruby",
@@ -244,7 +256,8 @@
 	},
 	"standardml": {
 		"name": "Standard ML",
-		"url": "https://en.wikipedia.org/wiki/Standard_ML"
+		"url": "https://en.wikipedia.org/wiki/Standard_ML",
+		"tag": "StandardML"
 	},
 	"swift": {
 		"name": "Swift",


### PR DESCRIPTION
As suggested in discussion #24, this makes the solution number in the result list link to the corresponding solution directory in the Primes repo. 

There is a small chance of this not fully working in older reports if languages change names or solutions change numbers, but as this will not happen often and won't really break anything in the app itself, I think this is acceptable.
(Fixing it would require a link between the report and the git commit the report is based on. That's a future extension to the benchmark tool and PrimeView we could consider at a later time, at the expense of a dependency on git in the former.)

Was marked as review and merge after #23, because it is based on the codebase in that PR.