### PR TITLE
Multithreaded leaderboard preset and filter summaries

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,7 +1,7 @@
 ﻿[*.{cs,vb}]
 
 # IDE0003: Remove qualification
-dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_field =false:suggestion
 
 # IDE0003: Remove qualification
 dotnet_diagnostic.IDE0003.severity = none

--- a/src/Frontend/Filters/FilterExtensions.cs
+++ b/src/Frontend/Filters/FilterExtensions.cs
@@ -14,7 +14,7 @@ namespace PrimeView.Frontend.Filters
 			if (filterImplementations.Count > 0)
 				source = source.Where(r => filterImplementations.Contains(r.Implementation));
 
-			return source.Where(r =>
+			var filteredResults = source.Where(r =>
 				r.IsMultiThreaded switch
 				{
 					true => page.FilterParallelMultithreaded,
@@ -38,6 +38,11 @@ namespace PrimeView.Frontend.Filters
 					_ => page.FilterBitsOther
 				}
 			);
+
+			return !page.OnlyHighestPassesPerSecondPerThreadPerLanguage ? filteredResults :
+				filteredResults
+					.GroupBy(r => r.Implementation)
+					.SelectMany(group => group.Where(r => r.PassesPerSecond == group.Max(r => r.PassesPerSecond)));
 		}
 	}
 }

--- a/src/Frontend/Filters/LeaderboardFilterPreset.cs
+++ b/src/Frontend/Filters/LeaderboardFilterPreset.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace PrimeView.Frontend.Filters
+﻿namespace PrimeView.Frontend.Filters
 {
 	public class LeaderboardFilterPreset : ResultFilterPreset
 	{

--- a/src/Frontend/Filters/ResultFilterPreset.cs
+++ b/src/Frontend/Filters/ResultFilterPreset.cs
@@ -28,36 +28,47 @@ namespace PrimeView.Frontend.Filters
 		[JsonIgnore]
 		public virtual bool IsFixed => false;
 
+		[JsonIgnore]
 		public IList<string> FilterImplementations
 			=> ImplementationText.SplitFilterValues();
 
+		[JsonIgnore]
 		public bool FilterParallelSinglethreaded 
 			=> !ParallelismText.SplitFilterValues().Contains(Constants.SinglethreadedTag);
 
+		[JsonIgnore]
 		public bool FilterParallelMultithreaded
 			=> !ParallelismText.SplitFilterValues().Contains(Constants.MultithreadedTag);
 
+		[JsonIgnore]
 		public bool FilterAlgorithmBase 
 			=> !AlgorithmText.SplitFilterValues().Contains(Constants.BaseTag);
 
+		[JsonIgnore]
 		public bool FilterAlgorithmWheel
 			=> !AlgorithmText.SplitFilterValues().Contains(Constants.WheelTag);
 
+		[JsonIgnore]
 		public bool FilterAlgorithmOther
 			=> !AlgorithmText.SplitFilterValues().Contains(Constants.OtherTag);
 
+		[JsonIgnore]
 		public bool FilterFaithful
 			=> !FaithfulText.SplitFilterValues().Contains(Constants.FaithfulTag);
 
+		[JsonIgnore]
 		public bool FilterUnfaithful
 			=> !FaithfulText.SplitFilterValues().Contains(Constants.UnfaithfulTag);
 
+		[JsonIgnore]
 		public bool FilterBitsUnknown
 			=> !BitsText.SplitFilterValues().Contains(Constants.UnknownTag);
 
+		[JsonIgnore]
 		public bool FilterBitsOne
 			=> !BitsText.SplitFilterValues().Contains(Constants.OneTag);
 
+		[JsonIgnore]
 		public bool FilterBitsOther
 			=> !BitsText.SplitFilterValues().Contains(Constants.OtherTag);
 	}

--- a/src/Frontend/Pages/Index.razor.cs
+++ b/src/Frontend/Pages/Index.razor.cs
@@ -3,9 +3,6 @@ using Microsoft.Extensions.Configuration;
 using PrimeView.Entities;
 using PrimeView.Frontend.Parameters;
 using PrimeView.Frontend.Tools;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace PrimeView.Frontend.Pages

--- a/src/Frontend/Pages/ReportDetails.razor
+++ b/src/Frontend/Pages/ReportDetails.razor
@@ -152,6 +152,16 @@
 								<button class="btn btn-primary" disabled="@AreFiltersClear" @onclick="ClearFilters">Clear filter</button>
 							</div>
 						</div>
+						<div class="row mx-2 mb-3">
+							<div class="col">
+								<div class="form-check">
+									<input class="form-check-input" type="checkbox" id="bl" @bind="OnlyHighestPassesPerSecondPerThreadPerLanguage">
+									<label class="form-check-label" for="bl">
+										For each language, only show the result with the highest passes per second, per thread
+									</label>
+								</div>
+							</div>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/src/Frontend/Pages/ReportDetails.razor.cs
+++ b/src/Frontend/Pages/ReportDetails.razor.cs
@@ -98,6 +98,9 @@ namespace PrimeView.Frontend.Pages
 			}
 		}
 
+		[QueryStringParameter("tp")]
+		public bool OnlyHighestPassesPerSecondPerThreadPerLanguage { get; set; } = false;
+
 		public IList<string> FilterImplementations
 			=> SplitFilterValueString(FilterImplementationText);
 

--- a/src/Frontend/Sorting/SortedTablePage.razor.cs
+++ b/src/Frontend/Sorting/SortedTablePage.razor.cs
@@ -3,7 +3,6 @@ using BlazorTable;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using PrimeView.Frontend.Parameters;
-using System;
 using System.Threading.Tasks;
 
 namespace PrimeView.Frontend.Sorting

--- a/src/JsonFileReader/ExtensionMethods.cs
+++ b/src/JsonFileReader/ExtensionMethods.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using PrimeView.Entities;
 using System;
-using System.Net.Http;
 using System.Text.Json;
 
 namespace PrimeView.JsonFileReader

--- a/src/JsonFileReader/ReportReader.cs
+++ b/src/JsonFileReader/ReportReader.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.Extensions.Configuration;
 using PrimeView.Entities;
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;


### PR DESCRIPTION
This PR adds:

- A baked-in preset for a multithreaded leaderboard. Filter settings are the same as the existing leaderboard, except it shows multithreaded results instead of single-threaded ones.
- Filter summaries to the filter card header when it's collapsed, and to preset labels (baked in or self-defined).