### PR TITLE
Only display successful results

### DIFF
--- a/src/Entities/Result.cs
+++ b/src/Entities/Result.cs
@@ -11,6 +11,7 @@
 		public string? Algorithm { get; set; }
 		public bool? IsFaithful { get; set; }
 		public int? Bits { get; set; }
+		public string? Status { get; set; }
 
 		public double? PassesPerSecond => (double?)Passes / Threads / Duration;
 		public bool IsMultiThreaded => Threads > 1;

--- a/src/Frontend/Filters/LeaderboardFilterPreset.cs
+++ b/src/Frontend/Filters/LeaderboardFilterPreset.cs
@@ -9,7 +9,7 @@ namespace PrimeView.Frontend.Filters
 			Name = "Leaderboard";
 			ImplementationText = string.Empty;
 			ParallelismText = Constants.MultithreadedTag;
-			AlgorithmText = new string[] { Constants.WheelTag, Constants.OtherTag}.JoinFilterValues();
+			AlgorithmText = new string[] { Constants.WheelTag, Constants.OtherTag }.JoinFilterValues();
 			FaithfulText = Constants.UnfaithfulTag;
 			BitsText = new string[] { Constants.UnknownTag, Constants.OtherTag }.JoinFilterValues();
 		}

--- a/src/Frontend/Filters/ResultFilterPreset.cs
+++ b/src/Frontend/Filters/ResultFilterPreset.cs
@@ -1,6 +1,5 @@
 ﻿using PrimeView.Frontend.Tools;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
 
 namespace PrimeView.Frontend.Filters
@@ -33,7 +32,7 @@ namespace PrimeView.Frontend.Filters
 			=> ImplementationText.SplitFilterValues();
 
 		[JsonIgnore]
-		public bool FilterParallelSinglethreaded 
+		public bool FilterParallelSinglethreaded
 			=> !ParallelismText.SplitFilterValues().Contains(Constants.SinglethreadedTag);
 
 		[JsonIgnore]
@@ -41,7 +40,7 @@ namespace PrimeView.Frontend.Filters
 			=> !ParallelismText.SplitFilterValues().Contains(Constants.MultithreadedTag);
 
 		[JsonIgnore]
-		public bool FilterAlgorithmBase 
+		public bool FilterAlgorithmBase
 			=> !AlgorithmText.SplitFilterValues().Contains(Constants.BaseTag);
 
 		[JsonIgnore]

--- a/src/Frontend/Frontend.csproj
+++ b/src/Frontend/Frontend.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.7" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+    <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Frontend/Pages/Index.razor.cs
+++ b/src/Frontend/Pages/Index.razor.cs
@@ -19,7 +19,7 @@ namespace PrimeView.Frontend.Pages
 		public int MaxReportCount { get; set; }
 
 		private ReportSummary[] summaries = null;
-		private int newMaxReportCount; 
+		private int newMaxReportCount;
 
 		public override Task SetParametersAsync(ParameterView parameters)
 		{

--- a/src/Frontend/Pages/ReportDetails.razor
+++ b/src/Frontend/Pages/ReportDetails.razor
@@ -227,7 +227,7 @@
 
 			<br />
 
-			var filteredItems = this.report.Results.ApplyFilters(this);
+			var filteredItems = this.report.Results.Viewable().ApplyFilters(this);
 			<Table TableItem="Result" Items="filteredItems" PageSize="0" ColumnReorder="false" ShowFooter="true" @ref="sortedTable" @onclick="FlagTableSortingChange">
 				@{ OnTableRefreshStart(); }
 				<Column TableItem="Result" Title="#" Sortable="false" Filterable="false" SetFooterValue="@($"{filteredItems.Count()}")" Align="Align.Right">

--- a/src/Frontend/Pages/ReportDetails.razor.cs
+++ b/src/Frontend/Pages/ReportDetails.razor.cs
@@ -271,8 +271,10 @@ namespace PrimeView.Frontend.Pages
 		}
 
 		private bool IsFilterPresetNameValid(string name)
-			=> !string.IsNullOrWhiteSpace(name)
-				&& (filterPresets == null || !filterPresets.Any(preset => preset.IsFixed && string.Equals(preset.Name, name, StringComparison.OrdinalIgnoreCase)));
+		{
+			return !string.IsNullOrWhiteSpace(name)
+						 && (filterPresets == null || !filterPresets.Any(preset => preset.IsFixed && string.Equals(preset.Name, name, StringComparison.OrdinalIgnoreCase)));
+		}
 
 		private async Task ApplyFilterPreset(int index)
 		{

--- a/src/Frontend/Parameters/QueryStringParameterAttribute.cs
+++ b/src/Frontend/Parameters/QueryStringParameterAttribute.cs
@@ -5,7 +5,7 @@ namespace PrimeView.Frontend.Parameters
 	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 	public sealed class QueryStringParameterAttribute : Attribute
 	{
-		public QueryStringParameterAttribute() {}
+		public QueryStringParameterAttribute() { }
 
 		public QueryStringParameterAttribute(string name)
 		{

--- a/src/Frontend/Parameters/QueryStringParameterExtensions.cs
+++ b/src/Frontend/Parameters/QueryStringParameterExtensions.cs
@@ -101,7 +101,9 @@ namespace PrimeView.Frontend.Parameters
 		}
 
 		private static string GetLocalStorageKey(ComponentBase component)
-			=> $"{component.GetType().Name}QueryParameters";
+		{
+			return $"{component.GetType().Name}QueryParameters";
+		}
 
 		private static object ConvertValue(StringValues value, Type type)
 		{
@@ -115,13 +117,19 @@ namespace PrimeView.Frontend.Parameters
 		}
 
 		private static object GetDefault(Type type)
-			=> type.IsValueType ? Activator.CreateInstance(type) : null;
+		{
+			return type.IsValueType ? Activator.CreateInstance(type) : null;
+		}
 
 		private static string ConvertToString(object value)
-			=> Convert.ToString(value, CultureInfo.InvariantCulture);
+		{
+			return Convert.ToString(value, CultureInfo.InvariantCulture);
+		}
 
 		private static PropertyInfo[] GetProperties(ComponentBase component)
-			=> component.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+		{
+			return component.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+		}
 
 		private static string GetQueryStringParameterName(PropertyInfo property)
 		{

--- a/src/Frontend/Sorting/SortingExtensions.cs
+++ b/src/Frontend/Sorting/SortingExtensions.cs
@@ -46,6 +46,8 @@ namespace PrimeView.Frontend.Sorting
 		}
 
 		public static bool EqualsIgnoreCaseOrNull(this string x, string y)
-			=> (x == null && y == null) || (x != null && y != null && x.Equals(y, StringComparison.OrdinalIgnoreCase));
+		{
+			return (x == null && y == null) || (x != null && y != null && x.Equals(y, StringComparison.OrdinalIgnoreCase));
+		}
 	}
 }

--- a/src/Frontend/Tools/LanguageInfo.cs
+++ b/src/Frontend/Tools/LanguageInfo.cs
@@ -13,10 +13,14 @@ namespace PrimeView.Frontend.Tools
 		public class KeyEqualityComparer : IEqualityComparer<LanguageInfo>
 		{
 			public bool Equals(LanguageInfo x, LanguageInfo y)
-				=> (x == null && y == null) || (x != null && y != null && x.Key == y.Key);
+			{
+				return (x == null && y == null) || (x != null && y != null && x.Key == y.Key);
+			}
 
 			public int GetHashCode([DisallowNull] LanguageInfo obj)
-				=> obj.Key.GetHashCode();
+			{
+				return obj.Key.GetHashCode();
+			}
 		}
 	}
 }

--- a/src/JsonFileReader/ExtensionMethods.cs
+++ b/src/JsonFileReader/ExtensionMethods.cs
@@ -47,7 +47,7 @@ namespace PrimeView.JsonFileReader
 			{
 				return JsonSerializer.Deserialize<T>(element.GetRawText(), serializerOptions);
 			}
-			catch (Exception ex) 
+			catch (Exception ex)
 			{
 				Console.WriteLine(ex);
 			}

--- a/src/JsonFileReader/ReportReader.cs
+++ b/src/JsonFileReader/ReportReader.cs
@@ -40,7 +40,7 @@ namespace PrimeView.JsonFileReader
 			{
 				reportJson = await this.httpClient.GetStringAsync(fileName);
 			}
-			catch	
+			catch
 			{
 				return null;
 			}
@@ -65,7 +65,7 @@ namespace PrimeView.JsonFileReader
 				{
 					reportFileNames = JsonSerializer.Deserialize<string[]>(await this.httpClient.GetStringAsync(this.indexFileName));
 				}
-				catch {}
+				catch { }
 			}
 
 			this.summaries = new();
@@ -87,7 +87,7 @@ namespace PrimeView.JsonFileReader
 				}
 			}
 
-			foreach (var item in stringReaderMap) 
+			foreach (var item in stringReaderMap)
 			{
 				string reportJson;
 				string fileName = item.Key;

--- a/src/JsonFileReader/S3BucketIndexReader.cs
+++ b/src/JsonFileReader/S3BucketIndexReader.cs
@@ -18,7 +18,7 @@ namespace PrimeView.JsonFileReader
 			{
 				indexElement = XElement.Parse(await httpClient.GetStringAsync(""));
 			}
-			catch 
+			catch
 			{
 				return null;
 			}


### PR DESCRIPTION
This makes the report details page only show result that have a `status` property that is either absent, or set to `"success"`.

As I ran a code cleanup on the solution, this PR does include some scattered whitespace changes. It may therefore be helpful to review this PR with "hide whitespace changes" enabled.