### PR TITLE
Pull status property from result

### DIFF
--- a/src/JsonFileReader/ReportReader.cs
+++ b/src/JsonFileReader/ReportReader.cs
@@ -190,7 +190,8 @@ namespace PrimeView.JsonFileReader
 				Label = element.GetString("label"),
 				Passes = element.GetInt32("passes"),
 				Solution = element.GetString("solution"),
-				Threads = element.GetInt32("threads")
+				Threads = element.GetInt32("threads"),
+				Status = element.GetString("status")
 			};
 
 			if (tagsElement.HasValue && int.TryParse(tagsElement.Value.GetString("bits"), out int bits))


### PR DESCRIPTION
When putting #31 together, I forgot to add the one line that actually pulls the status property from the result JSON.