### PR TITLE
Update to .NET 6.0, enable AOT compilation

### DIFF
--- a/.github/workflows/azure-static-web-apps-agreeable-mud-0b27ba210.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-mud-0b27ba210.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AGREEABLE_MUD_0B27BA210 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
-          skip_deploy_on_missing_secrets: true
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
+    - name: Install wasm-tools for AOT compilation
+      run: dotnet workload install wasm-tools
+
     - name: Publish Frontend project
       run: dotnet publish src/Frontend/Frontend.csproj -c Release -o release --nologo
     

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Publish Frontend project
       run: dotnet publish src/Frontend/Frontend.csproj -c Release -o release --nologo

--- a/README.md
+++ b/README.md
@@ -13,15 +13,20 @@ As the report reader back-end is isolated from the front-end (and added via depe
 
 ## Building
 
-The solution can be built by running the following command from the repository root directory, once [.NET 5.0](https://dotnet.microsoft.com/download/dotnet/5.0) is installed:
+The solution can be built by running the following commands from the repository root directory, once [.NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0) is installed:
 
 ```
+dotnet workload install wasm-tools
 dotnet publish
 ```
 
+Note that:
+* the first command installs the tools required for AOT compilation. That command has to be executed only once for any system PrimeView is built on.
+* the AOT compilation can take multiple minutes to complete.
+
 At the end of the build process, the location of the build output will be indicated in the following line:
 ```
-Frontend -> <repo root>\src\Frontend\bin\Debug\net5.0\publish\
+Frontend -> <repo root>\src\Frontend\bin\Debug\net6.0\publish\
 ```
 
 ## Implementation notes

--- a/src/Entities/Entities.csproj
+++ b/src/Entities/Entities.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+	<PropertyGroup>
 		<RootNamespace>PrimeView.Entities</RootNamespace>
 		<TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+		<RunAOTCompilation>true</RunAOTCompilation>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
 </Project>

--- a/src/Entities/Entities.csproj
+++ b/src/Entities/Entities.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<RootNamespace>PrimeView.Entities</RootNamespace>
 		<TargetFramework>net6.0</TargetFramework>
-		<RunAOTCompilation>true</RunAOTCompilation>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/src/Entities/Entities.csproj
+++ b/src/Entities/Entities.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 		<RootNamespace>PrimeView.Entities</RootNamespace>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Frontend/Frontend.csproj
+++ b/src/Frontend/Frontend.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 		<RootNamespace>PrimeView.Frontend</RootNamespace>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Frontend/Frontend.csproj
+++ b/src/Frontend/Frontend.csproj
@@ -1,26 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
-  <PropertyGroup>
+    <PropertyGroup>
 		<RootNamespace>PrimeView.Frontend</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+		<RunAOTCompilation>true</RunAOTCompilation>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\.editorconfig" Link=".editorconfig" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\.editorconfig" Link=".editorconfig" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Blazored.LocalStorage" Version="4.1.2" />
-    <PackageReference Include="BlazorTable" Version="1.15.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.7" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Blazored.LocalStorage" Version="4.1.5" />
+        <PackageReference Include="BlazorTable" Version="1.17.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+        <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
+        <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\JsonFileReader\JsonFileReader.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\JsonFileReader\JsonFileReader.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/src/JsonFileReader/JsonFileReader.csproj
+++ b/src/JsonFileReader/JsonFileReader.csproj
@@ -1,23 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+    <PropertyGroup>
 		<RootNamespace>PrimeView.JsonFileReader</RootNamespace>
 		<TargetFramework>net6.0</TargetFramework>
+		<RunAOTCompilation>true</RunAOTCompilation>
 		<Nullable>enable</Nullable>
-  </PropertyGroup>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\.editorconfig" Link=".editorconfig" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\.editorconfig" Link=".editorconfig" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="microsoft.extensions.configuration.binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+		<PackageReference Include="microsoft.extensions.configuration.binder" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Entities\Entities.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Entities\Entities.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/JsonFileReader/JsonFileReader.csproj
+++ b/src/JsonFileReader/JsonFileReader.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 		<RootNamespace>PrimeView.JsonFileReader</RootNamespace>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/JsonFileReader/JsonFileReader.csproj
+++ b/src/JsonFileReader/JsonFileReader.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
 		<RootNamespace>PrimeView.JsonFileReader</RootNamespace>
 		<TargetFramework>net6.0</TargetFramework>
-		<RunAOTCompilation>true</RunAOTCompilation>
 		<Nullable>enable</Nullable>
     </PropertyGroup>
 


### PR DESCRIPTION
This bumps the .NET version that PrimeView is based on from 5.0 to 6.0; the latter is an LTS version.

Furthermore, this PR enables Ahead-of-Time compilation for the PrimeView front-end. This means that users' browsers will be running "native" WebAssembly, instead of interpreted .NET IL bytecode. 