### PR TITLE
Add Algol 68G to language map

### DIFF
--- a/src/Frontend/wwwroot/data/langmap.json
+++ b/src/Frontend/wwwroot/data/langmap.json
@@ -3,6 +3,10 @@
 		"name": "Ada",
 		"url": "https://en.wikipedia.org/wiki/Ada_(programming_language)"
 	},
+    "algol68g": {
+        "name": "Algol 68G",
+        "url": "https://en.wikipedia.org/wiki/ALGOL_68"
+    },
 	"amd64": {
 		"name": "AMD64 machine code",
 		"url": "https://en.wikipedia.org/wiki/X86-64",


### PR DESCRIPTION
I noticed that there was not hyperlink for `algol68g`, so I'm adding one. Is there anything else that I need to do?