### PR TITLE
Update "lisp" entry in langmap.json

### DIFF
--- a/src/Frontend/wwwroot/data/langmap.json
+++ b/src/Frontend/wwwroot/data/langmap.json
@@ -199,8 +199,8 @@
 		"tag": "Lean4"
 	},
 	"lisp": {
-		"name": "Lisp",
-		"url": "https://en.wikipedia.org/wiki/Lisp_(programming_language)"
+		"name": "Common Lisp",
+		"url": "https://en.wikipedia.org/wiki/Common_Lisp"
 	},
 	"lua": {
 		"name": "Lua",


### PR DESCRIPTION
Because "Lisp" is a family of languages, seeing "Lisp" in the benchmark results leaves one wondering "what kind of Lisp?" The
[implementations](https://github.com/PlummersSoftwareLLC/Primes/tree/drag-race/PrimeLisp) are both in Common Lisp so I propose to display that on the results.

Although I don't really know anything about this project, my assumption is that this is a map from filename extensions ("lisp") to the name of the implementation language.