### PR TITLE
Add Unicat to language map

### DIFF
--- a/src/Frontend/wwwroot/data/langmap.json
+++ b/src/Frontend/wwwroot/data/langmap.json
@@ -355,6 +355,10 @@
 		"name": "Umple",
 		"url": "https://cruise.umple.org/umple/"
 	},
+	"unicat": {
+		"name": "Unicat",
+		"url": "https://esolangs.org/wiki/Unicat"
+	},
 	"v": {
 		"name": "V",
 		"url": "https://vlang.io/"


### PR DESCRIPTION
This adds the Unicat language to the language map. A solution in Unicat was introduced in https://github.com/PlummersSoftwareLLC/Primes/pull/938.