### PR TITLE
Fix Common Lisp solution links

### DIFF
--- a/src/Frontend/wwwroot/data/langmap.json
+++ b/src/Frontend/wwwroot/data/langmap.json
@@ -204,7 +204,8 @@
 	},
 	"lisp": {
 		"name": "Common Lisp",
-		"url": "https://en.wikipedia.org/wiki/Common_Lisp"
+		"url": "https://en.wikipedia.org/wiki/Common_Lisp",
+		"tag": "Lisp"
 	},
 	"lua": {
 		"name": "Lua",


### PR DESCRIPTION
After renaming the Lisp solutions to Common Lisp in the PrimeView language map the solution links in the results list broke because I forgot to add a "tag" element in the "lisp" JSON object. This PR addresses this. Fixes #69.