### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-agreeable-mud-0b27ba210.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-mud-0b27ba210.yml
@@ -1,5 +1,9 @@
 name: Azure Static Web Apps CI/CD
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy-to-github-pages:
 
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
Potential fix for [https://github.com/PlummersSoftwareLLC/PrimeView/security/code-scanning/1](https://github.com/PlummersSoftwareLLC/PrimeView/security/code-scanning/1)

To fix this issue, we need to add a `permissions:` block to ensure that the workflow grants only the required repository access to the GITHUB_TOKEN—following the least privilege principle. Since the workflow deploys to GitHub Pages by pushing content to the `pages` branch, it needs `contents: write` permission. To follow best practices, the `permissions:` block should be added at the job level, directly before `runs-on: ubuntu-latest` (on line 11), so as not to affect other jobs if added in future. No imports or extra definitions are necessary, just a YAML edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
